### PR TITLE
Refactor/reduce canopy metrics to core functionality

### DIFF
--- a/pyQSM/geometry/general.py
+++ b/pyQSM/geometry/general.py
@@ -5,6 +5,14 @@ import open3d as o3d
 from set_config import config, log
 
 
+def center_and_rotate(pcd, center=None):
+    center = pcd.get_center() if center is None else center
+    rot_90_x = np.array([[1,0,0],[0,0,-1],[0,1,0]])
+    pcd.translate(np.array([-x for x in center ]))
+    pcd.rotate(rot_90_x)
+    pcd.rotate(rot_90_x)
+    pcd.rotate(rot_90_x)
+    return center
 
 def zoom_pcd(zoom_region,
             pcd, 

--- a/pyQSM/geometry/point_cloud_processing.py
+++ b/pyQSM/geometry/point_cloud_processing.py
@@ -2,7 +2,11 @@ from matplotlib import pyplot as plt
 import open3d as o3d
 import numpy as np
 from numpy import array as arr
+from glob import glob
 
+import sys
+import os
+sys.path.insert(0,'/media/penguaman/code/ActualCode/Research/pyQSM/pyQSM/')
 from math_utils.general import (
     get_angles,
     get_center,
@@ -16,6 +20,24 @@ from set_config import log, config
 
 from viz.viz_utils import color_continuous_map, draw
 
+def join_pcd_files(files_path, pattern = '*', 
+                    voxel_size = None,
+                    write_to_file = True):
+    detail_files = glob(pattern,root_dir=files_path)
+    pcds=[]
+    for file in detail_files:
+        pcd = o3d.io.read_point_cloud(f'{files_path}/{file}')
+        print(f'{file} has {len(pcd.points)} points')
+        if voxel_size is not None:
+            pcd = pcd.voxel_down_sample(voxel_size)
+            print(f'{file} has {len(pcd.points)} points after voxel downsampling')
+        pcds.append(pcd)
+
+    joined = join_pcds(pcds)
+    if write_to_file:
+        o3d.io.write_point_cloud(f'{files_path}/joined.pcd', joined[0])
+    return joined
+    
 def join_pcds(pcds):
     pts = [arr(pcd.points) for pcd in pcds]
     colors = [arr(pcd.colors) for pcd in pcds]

--- a/pyQSM/geometry/reconstruction.py
+++ b/pyQSM/geometry/reconstruction.py
@@ -20,29 +20,8 @@ import open3d as o3d
 import numpy as np
 from numpy import asarray as arr
 
-import matplotlib.pyplot as plt
-
-from matplotlib import patches
-
-
 from open3d.io import read_point_cloud, write_point_cloud
 
-from math_utils.general import (
-    get_center
-)
-
-from set_config import config, log
-from geometry.mesh_processing import subdivide_mesh, get_surface_clusters, map_density
-from geometry.point_cloud_processing import ( filter_by_norm,
-    clean_cloud,
-    crop, get_shape,
-    orientation_from_norms,
-    filter_by_norm,
-    get_ball_mesh,
-    crop_by_percentile,
-    cluster_plus
-)
-from viz.viz_utils import iter_draw, draw
 from utils.io import save,load
 
 

--- a/pyQSM/qsm_generation.py
+++ b/pyQSM/qsm_generation.py
@@ -20,7 +20,7 @@ from math_utils.fit import cluster_DBSCAN, fit_shape_RANSAC, kmeans
 from math_utils.fit import choose_and_cluster, cluster_DBSCAN, fit_shape_RANSAC, kmeans
 from utils.io import save, load, save_line_set
 from utils.lib_integration import find_neighbors_in_ball
-from viz.color import color_on_percentile
+from viz.color import split_on_percentile
 from viz.viz_utils import color_continuous_map
 from math_utils.general import (
     get_angles,

--- a/pyQSM/tree_isolation.py
+++ b/pyQSM/tree_isolation.py
@@ -16,7 +16,7 @@ import matplotlib.pyplot as plt
 from open3d.io import read_point_cloud as read_pcd, write_point_cloud as write_pcd
 import tensorflow as tf
 
-from geometry.zoom import filter_to_region_pcds, zoom_pcd
+from geometry.general import filter_to_region_pcds, zoom_pcd
 from viz.ray_casting import project_pcd
 from set_config import config, log
 from math_utils.general import (

--- a/pyQSM/viz/color.py
+++ b/pyQSM/viz/color.py
@@ -331,16 +331,17 @@ def color_distribution(in_colors,oth_colors=None,cutoff=.01,elev=40, azim=110, r
     
     return corrected_rgb_full,hsv_fulls
 
-def color_on_percentile(pcd,
+def split_on_percentile(pcd,
                         val_list,
                         pctile,
-                        comp=lambda x,y:x>y ):
+                        comp=lambda x,y:x>y,
+                        color_on_percentile=False):
     if len(pcd.points)!= len(val_list):
         msg = f'length of val list does not match size of pcd'
         log.error(f'length of val list does not match size of pcd')
         raise ValueError(msg)
-
-    color_continuous_map(pcd,val_list)
+    if color_on_percentile:
+        color_continuous_map(pcd,val_list)
     val = np.percentile(val_list,pctile)
     highc_idxs = np.where(comp(val_list,val))[0]
     highc_pcd = pcd.select_by_index(highc_idxs,invert=False)

--- a/scripts/canopy_metrics_viz.py
+++ b/scripts/canopy_metrics_viz.py
@@ -1,0 +1,153 @@
+
+from open3d.visualization.tensorboard_plugin.util import to_dict_batch
+from pyQSM.viz.color import segment_hues
+
+import tensorflow as tf
+from open3d.visualization.tensorboard_plugin import summary
+
+def draw_hues(file_content,**kwargs):
+    seed, pcd, _, _ = file_content
+    # clean_pcd = get_downsample(pcd=pcd,normalize=False)
+    logdir = "src/logs/hues"
+    writer = tf.summary.create_file_writer(logdir)
+    hue_pcds,no_hue_pcds =segment_hues(pcd,seed,draw_gif=False, save_gif=False)
+    # no_hue_pcds = [x for x in no_hue_pcds if x is not None]
+    # target = no_hue_pcds[len(no_hue_pcds)-1]
+    with writer.as_default(): 
+        summary.add_3d(f'hue_pcd', to_dict_batch([pcd]), step=0, logdir=logdir)
+        for step in range(0,len(hue_pcds)):
+            summary.add_3d(f'hue_pcd', to_dict_batch([hue_pcds[step]]), step=step+1, logdir=logdir)
+            summary.add_3d(f'no_hue', to_dict_batch([no_hue_pcds[step]]), step=step+1, logdir=logdir)
+
+
+def clean_topo(topo):
+    lines = arr(topo.lines)
+    pts = arr(topo.points)
+    len_lines = [np.linalg.norm(pts[l[0]]-pts[l[1]]) for l in lines]
+    lines_w_len = [(l,llen) for l,llen in sorted(zip(lines,len_lines),key=lambda x: x[1])]
+    long_lines = np.where(np.array(len_lines)>2*np.percentile(len_lines,90))[0]
+
+    new_lines = arr([l for i,l in enumerate(lines) if i not in long_lines])
+    new_pts = pts[new_lines[:,0]] + pts[new_lines[:,0]]
+    new_pt_ids = {tuple(pt):idx for idx,pt in enumerate(new_pts)}
+    pt_ids = {idx:tuple(pt) for idx,pt in enumerate(pts)}
+    new_lines = [[new_pt_ids[tuple(pt_ids[i])] for i in l] for l in new_lines]
+    # lines = lines[:len(lines)-1]
+    breakpoint()
+    topo_new = o3d.geometry.LineSet()
+    topo_new.lines = o3d.utility.Vector2iVector(lines)
+    topo_new.points = o3d.utility.Vector3dVector(pts)
+    return topo_new
+
+def evaluate_shifts(file_content, 
+                    contraction=config['skeletonize']['init_contraction'],
+                    attraction=config['skeletonize']['init_attraction']):
+    seed, pcd, clean_pcd, shift = file_content
+    file_base = f'skels3/skel_{str(contraction).replace('.','pt')}_{str(attraction).replace('.','pt')}_seed{seed}' #_vox{vox}_ds{ds}'                    
+    contracted = contract(clean_pcd,shift)
+    draw(contracted)
+    topo = load_line_set(file_base)
+    draw(topo)
+    breakpoint()
+    return shift
+
+
+def read_shift_results(file_content, contraction=1, attraction=1, vox=0, ds=0):
+    """
+    Reads the results of get_shift from the skels3 directory.
+    
+    Args:
+        file_content: Tuple containing (seed, pcd, clean_pcd, shift_one)
+        contraction: Contraction factor used in get_shift
+        attraction: Attraction factor used in get_shift
+        vox: Voxel size used in get_shift
+        ds: Downsample factor used in get_shift
+        
+    Returns:
+        Dictionary containing the loaded results:
+        - 'contracted': The contracted point cloud
+        - 'total_shift': The total shift applied to the point cloud
+        - 'lines': The line set representing the skeleton
+        - 'points': The points of the skeleton
+    """
+    seed, pcd, clean_pcd, shift_one = file_content
+    cmag = np.array([np.linalg.norm(x) for x in shift_one])
+    highc_idxs = np.where(cmag>np.percentile(cmag,70))[0]
+    test = clean_pcd.select_by_index(highc_idxs, invert=True)
+    file_base = f'skel_{str(contraction).replace(".","pt")}_{str(attraction).replace(".","pt")}_seed{seed}_vox{vox}_ds{ds}'
+    
+    shift_path = f'skels3/{file_base}_total_shift.pkl'
+    contracted_path = f'data/skio/results/skio/skels3/{file_base}_contracted.pcd'
+    lines_path = f'skels3/{file_base}'
+
+    cyl_objects=f'data/skio/results/skio/cyls/{file_base}_cyls.pkl'
+    contained_idxs_file=f'data/skio/results/skio/cyls/{file_base}_contained_idxs.pkl'
+    topo_res_file=f'data/skio/results/skio/cyls/{file_base}_topo_graph.pkl'
+
+    results = {}
+    import os
+    
+    # Load the contracted point cloud
+    try:
+        results['total_shift'] = load(shift_path)
+        new107 = read_pcd('data/skio/ext_detail/new_107.pcd')
+        new108 = read_pcd('data/skio/ext_detail/new_108.pcd')
+        results['contracted'] = read_pcd(contracted_path)
+        results['topo'] = load_line_set(lines_path)
+    except Exception as e:
+        log.info(f'Error loading contracted point cloud for skels3/{file_base}: {e}')
+        breakpoint()
+    
+    try:
+        with open(cyl_objects,'rb') as f: results['cyl_objects'] = pickle.load(f)
+        with open(contained_idxs_file,'rb') as f: results['contained_idxs'] = pickle.load(f)
+        with open(topo_res_file,'rb') as f: results['topo_graph'] = pickle.load(f)
+    except Exception as e:
+        log.info(f'Error loading qsm_data for skels3/{file_base}: {e}')
+        breakpoint()
+
+    topo = results['topo']
+    total_shift = results['total_shift']        
+    contracted = results['contracted']
+
+    clean_c,inds = contracted.remove_statistical_outlier(nb_neighbors=20, std_ratio=.95)  
+    new_shift = total_shift[inds]
+    new_cmag = cmag[inds]
+
+
+
+    orig = contract(contracted,total_shift,invert=True)
+    draw(orig)
+    draw(contracted)
+    draw(topo)
+    
+    colored_clean_c = color_continuous_map(clean_c,new_cmag)
+    draw(colored_clean_c)
+    from geometry.skeletonize import skeleton_to_QSM
+    topology=extract_topology(clean_c)
+    topo=topology[0]
+    topology_graph = topology[1]
+    draw(topo)
+    breakpoint()    
+    # topo = clean_topo(topo)
+    all_cyl_pcd, cyls, cyl_objects , radii = skeleton_to_QSM(topo,topology_graph,new_shift)
+    breakpoint()    
+    draw(all_cyl_pcd)
+    draw(all_cyl_pcd)
+
+    edges = topology_graph.edges(data=True)
+    contained_idxs = [x[2].get('data') for x in edges]
+    edge_to_orig = {tuple((x[0],x[1])):x[2].get('data') for x in edges}
+
+    import pickle 
+    
+    cyl_objects=f'data/skio/results/skio/cyls/{file_base}_cyls.pkl'
+    contained_idxs_file=f'data/skio/results/skio/cyls/{file_base}_contained_idxs.pkl'
+    topo_res_file=f'data/skio/results/skio/cyls/{file_base}_topo_graph.pkl'
+    with open(cyl_objects,'wb') as f: pickle.dump(cyl_objects,f)
+    with open(contained_idxs_file,'wb') as f: pickle.dump(contained_idxs,f)
+    with open(topo_res_file,'wb') as f: pickle.dump(topology_graph,f)
+
+    breakpoint()
+    
+    return results

--- a/scripts/downgraded_from_src/canopy_metrics_removed_functions.py
+++ b/scripts/downgraded_from_src/canopy_metrics_removed_functions.py
@@ -1,0 +1,74 @@
+
+def get_trunk(file_content):
+    breakpoint()
+    seed, pcd, clean_pcd, shift_one = file_content
+    # file_base = f'skels3/skel_{str(contraction).replace('.','pt')}_{str(attraction).replace('.','pt')}_seed{seed}' #_vox{vox}_ds{ds}'0
+    lowc,highc = split_on_pct(clean_pcd,70,shift=shift_one)
+    draw([lowc])
+    breakpoint()
+    stem_pcd = get_stem_pcd(pcd=lowc)
+    breakpoint()
+
+
+
+def contraction_analysis(file, pcd, shift):
+
+    green = get_green_surfaces(pcd)
+    not_green = get_green_surfaces(pcd,True)
+    # draw(lowc_pcd)
+    draw(green)
+    draw(not_green)
+
+    c_mag = np.array([np.linalg.norm(x) for x in shift])
+    z_mag = np.array([x[2] for x in shift])
+
+    highc_idxs, highc, lowc = split_on_percentile(pcd,c_mag,70, color_on_percentile=True)
+
+    z_cutoff = np.percentile(z_mag,80)
+    log.info(f'{z_cutoff=}')
+    low_idxs = np.where(z_mag<=z_cutoff)[0]
+    lowc = clean_pcd.select_by_index(low_idxs)
+    ztrimmed_shift = shift[low_idxs]
+    ztrimmed_cmag = c_mag[low_idxs]
+    draw(lowc)
+    highc_idxs, highc, lowc = split_on_percentile(lowc,c_mag,70, color_on_percentile=True)
+
+    # color_continuous_map(test,c_mag)
+    highc_idxs = np.where(c_mag>np.percentile(c_mag,70))[0]
+    highc_pcd = test.select_by_index(highc_idxs)
+    lowc_pcd = test.select_by_index(highc_idxs,invert=True)
+    draw([lowc_pcd])
+    draw([highc_pcd])
+
+    breakpoint()
+    
+    lowc_detail = get_neighbors_kdtree(pcd,lowc_pcd)
+    draw(lowc_detail)
+    breakpoint()
+
+
+
+def draw_skel(pcd, 
+                seed,
+                shift=[], 
+                down_sample=True,
+                skeleton = None,
+                save_gif=False, 
+                out_path = None,
+                on_frames=25,
+                off_frames=25,
+                addnl_frame_duration=.05,
+                point_size=5):
+    out_path = out_path or f'data/results/gif/{seed}'
+    clean_pcd = pcd
+    if down_sample: clean_pcd = get_downsample(pcd=pcd, normalize=False)
+    if not skeleton:
+        skeleton = contract(clean_pcd,shift)
+    draw(skeleton)
+    # center_and_rotate(skeleton)
+    # center_and_rotate(clean_pcd)
+    # _ = center_and_rotate(skeleton) #Rotation makes contraction harder
+    gif_kwargs = {'on_frames': on_frames,'off_frames': off_frames, 'addnl_frame_duration':addnl_frame_duration,'point_size':point_size,'save':save_gif,'out_path':out_path}
+    # rotating_compare_gif(skeleton,clean_pcd, **gif_kwargs)
+    # rotating_compare_gif(contracted,clean_pcd, point_size=4, output=out_path,save = save_gif, on_frames = 50,off_frames=50, addnl_frame_duration=.03)
+    return skeleton


### PR DESCRIPTION
Some cleanup to prep for turning canopy metrics into a more formal pipeline 

- simplifying get files for loop_over_files - deciding on a more rigid folder structure 
- removing many different functions that are used in exploration but not 
   - A couple were moved to other files, but most were moved to scripts and split by 'visualization' and 'other' essentially
- Needed a place to move general translation functions  (center_and_rotate) so I renamed geometry.zoom to general
- Generally organized imports 
- updated name of color_on_percentile to split_on_percentile; added a color_on_percentile optional param